### PR TITLE
Only remove chainpoint containers in clear-containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ guard-ubuntu:
 ## clear-containers          : Stop and remove any running Docker containers
 .PHONY : clear-containers
 clear-containers:
-	@-containers=$$(sudo docker ps -aq); \
+	@-containers=$$(sudo docker ps -aq -f "label=org.chainpoint.service"); \
 	if [ "$${containers}" != "" ]; then \
 		echo "flushing docker containers..."; \
 		sudo docker stop $${containers}; \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
     environment:
       POSTGRES_USER: chainpoint
       POSTGRES_PASSWORD: chainpoint
+    labels:
+      org.chainpoint.service: "postgres"
 
   redis:
     image: redis:4.0.9-alpine
@@ -30,6 +32,8 @@ services:
     command:
       - redis-server
       - /usr/local/etc/redis/redis.conf
+    labels:
+      org.chainpoint.service: "redis"
 
   chainpoint-node:
     image: gcr.io/chainpoint-registry/github-chainpoint-chainpoint-node-src:8befa80d2459bbde431617e8129c6cc77fbb1b7b
@@ -51,3 +55,5 @@ services:
       CHAINPOINT_CORE_API_BASE_URI: "${CHAINPOINT_CORE_API_BASE_URI:-http://0.0.0.0}"
       CHAINPOINT_NODE_UI_PASSWORD: "${CHAINPOINT_NODE_UI_PASSWORD:-empty}"
       #DEBUG: "sequelize*"
+    labels:
+      org.chainpoint.service: "chainpoint-node"


### PR DESCRIPTION
- Assigns a label to each container (`org.chainpoint.service`)
- Only removes containers with that label

Should already be a little bit safer. This should work even before the upgrade as the old `clear-containers` would still be used.